### PR TITLE
Fix broken URL to the feedback repo

### DIFF
--- a/src/posts/free-as-in-beer.md
+++ b/src/posts/free-as-in-beer.md
@@ -69,7 +69,7 @@ Length of Pro subscription for different contributions will vary according to my
 
 To get your subscription set up, just send me an email with the details, from the email account you'd like associated with your new subscription, and I'll make it happen.
 
-If you'd like ideas for contributions, take a look through [the feedback repo](https://github.com/feedback) or the issues attached to the above repos, play around with [HTTP Toolkit](/) for yourself to find rough edges or missing features, or feel free to [get in touch](/contact/) for suggestions.
+If you'd like ideas for contributions, take a look through [the feedback repo](https://github.com/httptoolkit/httptoolkit) or the issues attached to the above repos, play around with [HTTP Toolkit](/) for yourself to find rough edges or missing features, or feel free to [get in touch](/contact/) for suggestions.
 
 If you look closely, all this is just an extension of the philosophy above! It's an expansion of the free tier - if you're a contributor to the project, HTTP Toolkit is now 100% FOSS for you - and a use of open source to feed that freemium virtuous cycle, and push the project further & higher.
 


### PR DESCRIPTION
It looks like this was a typo for https://github.com/httptoolkit/feedback. But that was renamed to https://github.com/httptoolkit/httptoolkit, so I picked the newer name.